### PR TITLE
Fix: Update GLTFLoader CDN to jsDelivr.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
     <div id="text-container"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="https://threejs.org/examples/js/loaders/GLTFLoader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
     <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Replaces the threejs.org examples URL for GLTFLoader.js with a jsDelivr CDN link, specifying version 0.128.0 to match the core Three.js library.

This aims to resolve issues where GLTFLoader was not being found, potentially due to CDN access problems or caching.