### PR TITLE
Create initial visual effects test with Three.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Visual Effects Test</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <script type="importmap">
+        {
+            "imports": {
+                "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+            }
+        }
+    </script>
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,122 @@
+// Import necessary Three.js modules
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+// Scene Setup
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x000000);
+
+// Camera Setup
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+
+// Renderer Setup
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+// Controls Setup
+let controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0);
+controls.enableDamping = true;
+controls.dampingFactor = 0.05;
+
+// Lighting Setup
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+scene.add(ambientLight);
+
+const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+directionalLight.position.set(5, 5, 5);
+scene.add(directionalLight);
+
+const directionalLightTarget = new THREE.Object3D();
+directionalLightTarget.position.set(0, 0, 0);
+scene.add(directionalLightTarget);
+directionalLight.target = directionalLightTarget;
+
+const spotLight = new THREE.SpotLight(0xffffff, 100);
+spotLight.distance = 3;
+spotLight.angle = Math.PI / 8; // Adjusted for potentially different model size
+spotLight.penumbra = 0.5;
+spotLight.decay = 2;
+
+// Model Setup & Loading
+let model;
+
+function adjustCameraForModel() {
+    if (!model) return;
+
+    const box = new THREE.Box3().setFromObject(model);
+    const size = new THREE.Vector3();
+    box.getSize(size);
+    const center = new THREE.Vector3();
+    box.getCenter(center); // Get the actual center of the model
+
+    // Reposition model to origin
+    model.position.sub(center);
+    scene.add(model); // Add model to scene *after* repositioning
+
+    if (size.x === 0 && size.y === 0 && size.z === 0) return;
+
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const fov = camera.fov * (Math.PI / 180);
+    let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
+
+    // Add some distance for padding
+    cameraZ *= 1.5;
+
+    camera.position.set(0, 0, cameraZ);
+
+    // Update controls target to look at the model's new origin (0,0,0)
+    controls.target.set(0, 0, 0);
+    controls.update();
+    camera.lookAt(0, 0, 0);
+    camera.updateProjectionMatrix();
+}
+
+const gltfLoader = new GLTFLoader();
+const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/lasers-test-1/main/cube-beveled-silver.glb';
+
+gltfLoader.load(
+    modelUrl,
+    (gltf) => {
+        model = gltf.scene;
+
+        // Configure and attach the SpotLight to the model
+        const spotLightTargetObject = new THREE.Object3D();
+        model.add(spotLightTargetObject);
+        spotLightTargetObject.position.set(0, 0, 0);
+
+        spotLight.target = spotLightTargetObject;
+        model.add(spotLight);
+
+        adjustCameraForModel(); // Call this after model is processed
+    },
+    (xhr) => {
+        console.log((xhr.loaded / xhr.total * 100) + '% loaded');
+    },
+    (error) => {
+        console.error('An error occurred loading the GLB model:', error);
+    }
+);
+
+// Animation Loop
+function animate() {
+    requestAnimationFrame(animate);
+    if (controls.enableDamping) {
+        controls.update();
+    }
+    renderer.render(scene, camera);
+}
+animate();
+
+// Event Listeners
+window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    if (model) {
+        adjustCameraForModel();
+    } else {
+        camera.updateProjectionMatrix();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+canvas {
+    display: block;
+}


### PR DESCRIPTION
This commit introduces a basic Three.js setup to display a GLTF model. It includes:
- index.html: Basic HTML structure with an import map for Three.js.
- style.css: Minimal styling to ensure the canvas fills the screen.
- main.js:
    - Sets up a Three.js scene, camera, and WebGL renderer.
    - Implements OrbitControls for camera manipulation.
    - Includes ambient, directional, and a model-parented spotlight.
    - Loads a .glb model (cube-beveled-silver.glb) from an external URL.
    - Dynamically adjusts the camera to frame the loaded model.
    - Handles window resize events to maintain aspect ratio and model framing.