### PR TITLE
I've reduced the horizontal separation of camera-based laser origins.

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,7 +190,7 @@ function updateLasers() {    // New function
     }
 
     laserConfigs.forEach((config, laserIndex) => { // Added laserIndex directly
-        const separation = 0.1; // Horizontal separation between lasers
+        const separation = 0.01; // New, much smaller value
         const numLasers = LASER_COLORS.length;
         const offsetAmount = (laserIndex - (numLasers - 1) / 2) * separation;
 


### PR DESCRIPTION
This commit addresses your feedback that lasers, while originating relative to the camera, appeared too spread out (from the 'width sides of the screen').

- In `updateLasers`, the `separation` constant used for calculating the horizontal offset of laser origins from the camera's center has been reduced from `0.1` to `0.01`.
- This makes the four lasers originate from points much closer to each other and to the camera's direct line of sight, providing a more concentrated emission effect from the camera's viewpoint.