### PR TITLE
Replace GLTF model and adjust screen occupancy.

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,7 +92,6 @@ function adjustCameraForModel() {
     const fovInRadians = THREE.MathUtils.degToRad(camera.fov);
     let cameraZ = (modelHeight / 2) / Math.tan(fovInRadians / 2);
     cameraZ *= 2; // Original adjustment for 50% canvas height
-    cameraZ *= 2; // Further adjustment to make it 50% smaller than current
     camera.position.set(0, 0, cameraZ);
 
     // Update controls target to look at the model's new origin (0,0,0)
@@ -103,7 +102,7 @@ function adjustCameraForModel() {
 }
 
 const gltfLoader = new GLTFLoader();
-const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/lasers-test-1/main/cube-beveled-silver.glb';
+const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/lasers-test-1/feat/add-second-red-laser/HoodedCory_NewHood_Darker.DecimatedFace.glb';
 
 // Laser Line Setup
 const laserMaterial = new THREE.LineBasicMaterial({ color: 0xff0000 }); // Red laser


### PR DESCRIPTION
This commit updates the 3D model used in the scene:
- The model is changed to 'HoodedCory_NewHood_Darker.DecimatedFace.glb'.
- The camera positioning logic in `adjustCameraForModel` has been modified so that the new model occupies approximately 50% of the screen height.

The `modelUrl` variable was updated to the new model's URL, and the calculation for `camera.position.z` within `adjustCameraForModel` was adjusted to achieve the desired screen occupancy.