### PR TITLE
Resize model to 50% of its current size.

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,6 +92,7 @@ function adjustCameraForModel() {
     const fovInRadians = THREE.MathUtils.degToRad(camera.fov);
     let cameraZ = (modelHeight / 2) / Math.tan(fovInRadians / 2);
     cameraZ *= 2; // Original adjustment for 50% canvas height
+    cameraZ *= 2; // Double the distance again, making the model appear half as tall.
     camera.position.set(0, 0, cameraZ);
 
     // Update controls target to look at the model's new origin (0,0,0)


### PR DESCRIPTION
This commit further adjusts the camera distance in `adjustCameraForModel` to make the 3D model appear 50% smaller than its previous size.

The `cameraZ` calculation was modified by adding an additional multiplication by 2, effectively doubling the camera's distance from the model compared to the immediately preceding state. This results in the model occupying a smaller portion of the screen (approximately 25% of the screen height, which is 50% of its previous 50% screen height occupancy).