### PR TITLE
Fix: Ensure all lasers target the model from random positions.

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,8 +48,8 @@ let model;
 
 // Laser Global Variables
 let laserLine;
-const laserOrigin = new THREE.Vector3(-10, 1, 0); // Example starting point
-const initialLaserDirection = new THREE.Vector3(1, 0, 0).normalize(); // Example initial direction
+const laserOrigin = new THREE.Vector3(Math.random() * 20 - 10, Math.random() * 20 - 10, Math.random() * 20 - 10);
+const initialLaserDirection = new THREE.Vector3().subVectors(new THREE.Vector3(0,0,0), laserOrigin).normalize();
 
 // Second Laser Global Variables
 let laserLine2;


### PR DESCRIPTION
This commit addresses an issue where the first laser did not have a random origin and its initial direction was fixed, unlike the other three lasers.

The following changes were made:
- Modified the initialization of `laserOrigin` (for the first laser) to be a random THREE.Vector3, consistent with `laserOrigin2`, `laserOrigin3`, and `laserOrigin4`.
- Modified `initialLaserDirection` (for the first laser) to be calculated by pointing from its random origin towards the world origin (0,0,0), where the model is centered. This makes its targeting behavior consistent with the other lasers.

All lasers now correctly originate from random positions and target the 3D object. The `interactiveObjects` array was already being correctly populated and used by all laser update functions.