### PR TITLE
Fix: Resolve blank screen issue and complete feature removal/disabling

### DIFF
--- a/main.js
+++ b/main.js
@@ -589,29 +589,29 @@ function animate() {
     // if (spotlightDownLaserLine && spotLightDown && spotLightDown.target && spotLightDown.parent === model) { // Check if model is parent
     //     const worldSpotLightDownPos = new THREE.Vector3();
     //     spotLightDown.getWorldPosition(worldSpotLightDownPos);
-
-        const worldSpotLightDownTargetPos = new THREE.Vector3();
-        spotLightDown.target.getWorldPosition(worldSpotLightDownTargetPos);
-
-        const points = [];
-        points.push(worldSpotLightDownPos.clone());
-        // points.push(worldSpotLightDownTargetPos.clone());
-        // spotlightDownLaserLine.geometry.setFromPoints(points);
-        // spotlightDownLaserLine.geometry.attributes.position.needsUpdate = true;
+    //
+    //     const worldSpotLightDownTargetPos = new THREE.Vector3();
+    //     spotLightDown.target.getWorldPosition(worldSpotLightDownTargetPos);
+    //
+    //     const points = [];
+    //     points.push(worldSpotLightDownPos.clone());
+    //     points.push(worldSpotLightDownTargetPos.clone());
+    //     spotlightDownLaserLine.geometry.setFromPoints(points);
+    //     spotlightDownLaserLine.geometry.attributes.position.needsUpdate = true;
     // }
 
     // if (spotlightFaceLaserLine && spotLightFace && spotLightFace.target && spotLightFace.parent === model) { // Check if model is parent
     //     const worldSpotLightFacePos = new THREE.Vector3();
     //     spotLightFace.getWorldPosition(worldSpotLightFacePos);
-
-        const worldSpotLightFaceTargetPos = new THREE.Vector3();
-        spotLightFace.target.getWorldPosition(worldSpotLightFaceTargetPos);
-
-        const points = [];
-        points.push(worldSpotLightFacePos.clone());
-        // points.push(worldSpotLightFaceTargetPos.clone());
-        // spotlightFaceLaserLine.geometry.setFromPoints(points);
-        // spotlightFaceLaserLine.geometry.attributes.position.needsUpdate = true;
+    //
+    //     const worldSpotLightFaceTargetPos = new THREE.Vector3();
+    //     spotLightFace.target.getWorldPosition(worldSpotLightFaceTargetPos);
+    //
+    //     const points = [];
+    //     points.push(worldSpotLightFacePos.clone());
+    //     points.push(worldSpotLightFaceTargetPos.clone());
+    //     spotlightFaceLaserLine.geometry.setFromPoints(points);
+    //     spotlightFaceLaserLine.geometry.attributes.position.needsUpdate = true;
     // }
 
     // Update all rave-laser-system-1 lines using the new reusable function


### PR DESCRIPTION
This commit addresses a blank screen issue that arose after attempting to remove lighting helpers and temporarily disable spotlight lasers. The root cause was orphaned lines of code in the animate function referencing variables from within the commented-out spotlight laser update blocks, leading to a JavaScript error.

The commit includes:
- Correction to ensure all spotlight laser update code in the animate function is fully commented out, resolving the blank screen.
- Original changes:
    - Commented out DirectionalLightHelper, SpotLightDownHelper, and SpotLightFaceHelper.
    - Commented out the initialization and update logic for spotlight lasers.