### PR TITLE
Double the speed of the rave lasers

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,8 +39,8 @@ const CAMERA_ROTATION_THRESHOLD = THREE.MathUtils.degToRad(15); // Min camera ro
 const CAMERA_POSITION_THRESHOLD = 0.1; // Min camera position change (world units) for 'significant movement'
 const RAVE_LASER_SYSTEM_1_STILLNESS_LIMIT = 3.0; // Duration (seconds) camera must be 'still' to trigger rave-laser-system-1 jump
 
-const BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY = 0.5; // Base rave-laser-system-1 pulse frequency (cycles per second) when camera is still
-const RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY = 5.0; // How much camera movement speed influences pulse frequency
+const BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY = 1.0; // Base rave-laser-system-1 pulse frequency (cycles per second) when camera is still
+const RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY = 10.0; // How much camera movement speed influences pulse frequency
 const MIN_RAVE_LASER_SYSTEM_1_BRIGHTNESS = 0.3; // Minimum brightness for pulsing rave-laser-system-1 material (range 0-1)
 const MAX_RAVE_LASER_SYSTEM_1_BRIGHTNESS = 1.0; // Maximum brightness for pulsing rave-laser-system-1 material (range 0-1)
 


### PR DESCRIPTION
This change doubles the pulse frequency and sensitivity of the rave lasers by modifying the following parameters in main.js:

- `BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY` was changed from 0.5 to 1.0.
- `RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY` was changed from 5.0 to 10.0.

These changes are intended to make the visual elements of the rave laser system change at twice their current speed.