### PR TITLE
Increase the rate of laser origin changes by 2x

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,10 +37,10 @@ const clock = new THREE.Clock();
 const RAVE_LASER_SYSTEM_1_ORIGIN_SPHERE_RADIUS = 10; // Radius for the invisible sphere where rave-laser-system-1 originate
 const CAMERA_ROTATION_THRESHOLD = THREE.MathUtils.degToRad(15); // Min camera rotation (radians) to be considered 'significant movement'
 const CAMERA_POSITION_THRESHOLD = 0.1; // Min camera position change (world units) for 'significant movement'
-const RAVE_LASER_SYSTEM_1_STILLNESS_LIMIT = 3.0; // Duration (seconds) camera must be 'still' to trigger rave-laser-system-1 jump
+const RAVE_LASER_SYSTEM_1_STILLNESS_LIMIT = 1.5; // Duration (seconds) camera must be 'still' to trigger rave-laser-system-1 jump
 
-const BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY = 1.0; // Base rave-laser-system-1 pulse frequency (cycles per second) when camera is still
-const RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY = 10.0; // How much camera movement speed influences pulse frequency
+const BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY = 0.5; // Base rave-laser-system-1 pulse frequency (cycles per second) when camera is still
+const RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY = 5.0; // How much camera movement speed influences pulse frequency
 const MIN_RAVE_LASER_SYSTEM_1_BRIGHTNESS = 0.3; // Minimum brightness for pulsing rave-laser-system-1 material (range 0-1)
 const MAX_RAVE_LASER_SYSTEM_1_BRIGHTNESS = 1.0; // Maximum brightness for pulsing rave-laser-system-1 material (range 0-1)
 


### PR DESCRIPTION
This change addresses your feedback to increase the speed at which rave laser origins change, while keeping the laser intensity/brightness pulsing speed at its original rate.

Changes made in main.js:
- Reverted `BASE_RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY` to 0.5.
- Reverted `RAVE_LASER_SYSTEM_1_PULSE_FREQUENCY_SENSITIVITY` to 5.0.
- Halved `RAVE_LASER_SYSTEM_1_STILLNESS_LIMIT` from 3.0 to 1.5.

This makes the lasers change their origin points more frequently, particularly when the camera is stationary, effectively doubling this aspect of their movement speed.